### PR TITLE
fix: lxc resolves to std::lexicographical_compare

### DIFF
--- a/snippets/cpp.json
+++ b/snippets/cpp.json
@@ -375,15 +375,15 @@
 		"description": "Code snippet for 'is_sorted_until'"
 		},
 
-		"lexigraphical_compare": {
+		"lexicographical_compare": {
 		"prefix": "lxc",
 		"body": [
-			"if (std::lexigraphical_compare(std::begin(${1:container}), std::end(${1:container}),",
+			"if (std::lexicographical_compare(std::begin(${1:container}), std::end(${1:container}),",
 			"  std::begin($2), std::end($3)) {",
 			"  $4",
 			"}"
 		],
-		"description": "Code snippet for 'lexigraphical_compare'"
+		"description": "Code snippet for 'lexicographical_compare'"
 		},
 
 		"lower_bound": {


### PR DESCRIPTION
The snippet lxc should resolve to std::lexicographical_compare and not to std::lexigraphical_compare. This fixes a small typo.

Before:
```
    if (std::lexigraphical_compare(std::begin(container), std::end(container),
      std::begin(), std::end()) {
      
    }
```
After:
```
    if (std::lexicographical_compare(std::begin(container), std::end(container),
      std::begin(), std::end()) {
      
    }
```